### PR TITLE
Enhance/hide sensitive data

### DIFF
--- a/providers/command.rb
+++ b/providers/command.rb
@@ -9,7 +9,7 @@ action :execute do
     command "#{node['wp-cli']['bin']} #{command}#{args_str}#{stdin}"
     cwd new_resource.cwd
     user new_resource.user
-    sensitive :true
+    sensitive new_resource.sensitive
   end
 end
 

--- a/providers/command.rb
+++ b/providers/command.rb
@@ -9,6 +9,7 @@ action :execute do
     command "#{node['wp-cli']['bin']} #{command}#{args_str}#{stdin}"
     cwd new_resource.cwd
     user new_resource.user
+    sensitive :true
   end
 end
 

--- a/providers/command.rb
+++ b/providers/command.rb
@@ -5,7 +5,7 @@ action :execute do
 
   args_str = args_to_s(args)
 
-  execute "wp-cli #{command}#{args_str}" do
+  execute "wp-cli #{command}" do
     command "#{node['wp-cli']['bin']} #{command}#{args_str}#{stdin}"
     cwd new_resource.cwd
     user new_resource.user

--- a/resources/command.rb
+++ b/resources/command.rb
@@ -6,7 +6,7 @@ attribute :command, :kind_of => String, :name_attribute => true
 attribute :cwd, :kind_of => String, :default => nil
 attribute :stdin, :kind_of => String, :default => nil
 attribute :user, :kind_of => String, :default => nil
-attribute :sensitive, :kind_of => [TrueClass, FalseClass], :default => :false
+attribute :sensitive, :kind_of => String, :default => false
 
 def initialize(*args)
   super

--- a/resources/command.rb
+++ b/resources/command.rb
@@ -6,7 +6,7 @@ attribute :command, :kind_of => String, :name_attribute => true
 attribute :cwd, :kind_of => String, :default => nil
 attribute :stdin, :kind_of => String, :default => nil
 attribute :user, :kind_of => String, :default => nil
-attribute :sensitive, :kind_of => String, :default => false
+attribute :sensitive, :kind_of => [TrueClass, FalseClass], :default => false
 
 def initialize(*args)
   super

--- a/resources/command.rb
+++ b/resources/command.rb
@@ -6,6 +6,7 @@ attribute :command, :kind_of => String, :name_attribute => true
 attribute :cwd, :kind_of => String, :default => nil
 attribute :stdin, :kind_of => String, :default => nil
 attribute :user, :kind_of => String, :default => nil
+attribute :sensitive, :kind_of => [TrueClass, FalseClass], :default => :false
 
 def initialize(*args)
   super


### PR DESCRIPTION
@rubemz This PR implement [sensitive](https://docs.chef.io/resource_common.html#attributes) attribute in `execute` resource.
In order to make it effective, I was forced to remove the full list of args in the name of the `execute` resource in the `provider`, otherwise will still appears in logs.
I did not bumped the version, since you control this, lemme know if you want that.
If you want to discuss further ping me on hipchat.